### PR TITLE
Added className option that's used when the element is floating (fixed)

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -8,7 +8,8 @@
 (function($){
 	$.fn.sticky = function(options) {
 		var defaults = {
-			topSpacing: 0
+			topSpacing: 0,
+			className: 'is-sticky'
 		};  
 		var options = $.extend(defaults, options);
 		return this.each(function() {
@@ -24,10 +25,10 @@
 			$(window).scroll(function(){
 				elementPosition = stickyElement.offset().top - $(window).scrollTop();
 				if (elementPosition <= topPadding) {
-					stickyElement.css("position","fixed").css("top",topPadding);
+					stickyElement.css("position","fixed").css("top",topPadding).addClass(options.className);
 				}
 				if ($(window).scrollTop() <= regPosition - topPadding) {
-					stickyElement.css("position","static").css("top",$(window).scrollTop());
+					stickyElement.css("position","static").css("top",$(window).scrollTop()).removeClass(options.className);
 				}
 			});
 		});


### PR DESCRIPTION
When you scroll the element gets class 'floating'. When you scroll back to the top and the element is static again, the class 'floating' is removed.

```
$(document).ready(function(){
    $("#sticker").sticky({className: 'floating'});
});
```
