### PR TITLE
Move sticked elements to their position on page load

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -83,4 +83,7 @@
 			});
 		});
 	};
+	$(function() {
+		setTimeout(scroller, 0);
+	});
 })(jQuery);


### PR DESCRIPTION
For when you load a page that has a #hash in the URL, the sticked elements are not moved and sticked in their proper position until you scroll. This fixes that issue.
