### PR TITLE
Semi-colon for minify-ing

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -72,7 +72,7 @@
                     wrapper = $('<div></div>')
                         .attr('id', stickyId + '-sticky-wrapper')
                         .addClass(o.wrapperClassName);
-                    stickyElement.wrapAll(wrapper)
+                    stickyElement.wrapAll(wrapper);
                     var stickyWrapper = stickyElement.parent();
                     stickyWrapper.css('height', stickyElement.outerHeight());
                     sticked.push({


### PR DESCRIPTION
this semi-colon lets this file be minified without errors. placing the var on the same line as the jquery statement caused an error.
