### PR TITLE
'float' appears to be a reserved word and needs quoting

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -86,7 +86,7 @@
           }
 
           if (stickyElement.css("float") == "right") {
-            stickyElement.css({float:"none"}).parent().css({float:"right"});
+            stickyElement.css({"float":"none"}).parent().css({"float":"right"});
           }
 
           var stickyWrapper = stickyElement.parent();


### PR DESCRIPTION
The unquoted use of the string "float" prevents YUI compressor from minifying the source file, and throws an error "invalid property id".
