### PR TITLE
Bugfix: changing target of $.extend, so that defaults aren't overwritten by options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ This is how it works:
 - `bottomSpacing`: Pixels between the page bottom and the element's bottom.
 - `className`: CSS class added to the element and its wrapper when "sticked".
 - `wrapperClassName`: CSS class added to the wrapper.
+- `stuckClassName`: CSS class added to wrapper when element is re-stuck to page.
+- `stickTo`: jQuery selector string of element at which point the sticky element should unstick from scrolling, re-stick to page. (May be passed as HTML5 data attribute on sticky element.)
+- `stickDelay`: Integer that is the number of pixels sticky element should scroll off screen before sticking to scroll. (May be passed as HTML5 data attribute on sticky element.)
 
 ## Methods
 

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -3,8 +3,9 @@
 // Author: Anthony Garand
 // Improvements by German M. Bravo (Kronuz) and Ruud Kamphuis (ruudk)
 // Improvements by Leonardo C. Daronco (daronco)
+// Improvements by Hunter Dougless (hntrdglss)
 // Created: 2/14/2011
-// Date: 2/12/2012
+// Date: 12/1/2012
 // Website: http://labs.anthonygarand.com/sticky
 // Description: Makes an element on the page stick on the screen as you scroll
 //       It will only set the 'top' and 'position' of your element, you
@@ -15,9 +16,12 @@
       topSpacing: 0,
       bottomSpacing: 0,
       className: 'is-sticky',
+      stuckClassName: 'is-stuck',
       wrapperClassName: 'sticky-wrapper',
       center: false,
-      getWidthFrom: ''
+      getWidthFrom: '',
+      stickTo: '',
+      stickDelay: 0
     },
     $window = $(window),
     $document = $(document),
@@ -32,15 +36,29 @@
       for (var i = 0; i < sticked.length; i++) {
         var s = sticked[i],
           elementTop = s.stickyWrapper.offset().top,
-          etse = elementTop - s.topSpacing - extra;
-
+          etse = elementTop - s.topSpacing - extra + s.stickDelay,
+          ebse = (s.stickTo.length) ? s.stickTo.outerHeight() + s.stickTo.offset().top
+             - s.stickyElement.outerHeight() - s.bottomSpacing - s.topSpacing - extra : null;
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
             s.stickyElement
               .css('position', '')
-              .css('top', '');
+              .css('top', '')
+              .removeClass(s.className);
             s.stickyElement.parent().removeClass(s.className);
             s.currentTop = null;
+          }
+        }
+        else if (ebse !== null && scrollTop > ebse) {
+          if (s.stickyElement.hasClass(s.className)) {
+            // var newTop = scrollTop - $(s.stickyElement.parent().offsetParent()).offset().top + s.topSpacing; // if scrolling too quickly, sticks past end
+            var newTop = s.stickTo.outerHeight() + s.stickTo.offset().top - s.stickyElement.outerHeight() - 100 - $(s.stickyElement.parent().offsetParent()).offset().top + s.topSpacing;
+            s.stickyElement
+              .css('position', 'absolute')
+              .css('top', newTop)
+              .removeClass(s.className);
+            s.stickyElement.parent().removeClass(s.className).addClass(s.stuckClassName);
+            s.currentTop = newTop;
           }
         }
         else {
@@ -60,7 +78,7 @@
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 
-            s.stickyElement.parent().addClass(s.className);
+            s.stickyElement.parent().removeClass(s.stuckClassName).addClass(s.className);
             s.currentTop = newTop;
           }
         }
@@ -91,14 +109,21 @@
 
           var stickyWrapper = stickyElement.parent();
           stickyWrapper.css('height', stickyElement.outerHeight());
+
+          var stickTo = ($(stickyElement.data("stick-to")).length) ? $(stickyElement.data("stick-to")) : $(o.stickTo);
+          var stickDelay = (stickyElement.data("stick-delay")) ? stickyElement.data("stick-delay") : o.stickDelay;
+
           sticked.push({
             topSpacing: o.topSpacing,
             bottomSpacing: o.bottomSpacing,
             stickyElement: stickyElement,
+            stickTo: stickTo,
+            stickDelay: stickDelay,
             currentTop: null,
             stickyWrapper: stickyWrapper,
             className: o.className,
-            getWidthFrom: o.getWidthFrom
+            getWidthFrom: o.getWidthFrom,
+            stuckClassName: o.stuckClassName
           });
         });
       },


### PR DESCRIPTION
Currently, plugin defaults are overwritten with initialized options, resulting in any newly instantiated stickies inheriting any previously created sticky options.

I've changed line 74 to fix this, setting the $.extend target to be an empty object, instead of the plugin defaults variable.
