### PR TITLE
Update resizer to handle the case where a stickyElement changes height

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -68,6 +68,14 @@
     },
     resizer = function() {
       windowHeight = $window.height();
+      $wrapper = $(this);
+      $(".sticky-wrapper").each(function() {
+        var stickyWrapper = $(this);
+        var outerHeight = stickyWrapper.children().first().outerHeight();
+        if (stickyWrapper.data("height") != outerHeight) {
+          $(this).css('height', outerHeight);
+        }
+      });
     },
     methods = {
       init: function(options) {
@@ -90,7 +98,9 @@
           }
 
           var stickyWrapper = stickyElement.parent();
-          stickyWrapper.css('height', stickyElement.outerHeight());
+          var outerHeight = stickyElement.outerHeight();
+          stickyWrapper.data('height', outerHeight);
+          stickyWrapper.css('height', outerHeight);
           sticked.push({
             topSpacing: o.topSpacing,
             bottomSpacing: o.bottomSpacing,


### PR DESCRIPTION
This change fixes a bug where resizing a window changes the height of a sticky element.  
![Screen Shot 2013-04-26 at 10 56 23 ](https://f.cloud.github.com/assets/320207/431654/c13c3722-ae8e-11e2-96a2-7146d4f00816.png)

If you've got a buttonset like the one above, and you resize the window, you can end up with something like this: 
![Screen Shot 2013-04-26 at 10 56 47 ](https://f.cloud.github.com/assets/320207/431657/d3c8f4ac-ae8e-11e2-8dc6-a65e64e5b343.png)

The answer is to recalculate the height of each stickyElement whenever a resize event happens.  This particular pull request is a bit more complicated than my first attempt, because it seems like changing the style when not necessary might introduce a performance hit by triggering a reflow.  (This is why I'm caching the height of the element in a data() of the stickyWrapper.)
