### PR TITLE
Add option setWidth to prevent width being set on "stickied" element

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This is how it works:
 - `className`: CSS class added to the element and its wrapper when "sticked".
 - `wrapperClassName`: CSS class added to the wrapper.
 - `getWidthFrom`: Selector of element referenced to set fixed width of "sticky" element.
+- `setWidth`: Choose whether the "sticky" element should have a fixed width set when "sticked". Default: `true`.
 
 ## Methods
 

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -17,7 +17,8 @@
       className: 'is-sticky',
       wrapperClassName: 'sticky-wrapper',
       center: false,
-      getWidthFrom: ''
+      getWidthFrom: '',
+      setWidth: true
     },
     $window = $(window),
     $document = $(document),
@@ -56,7 +57,7 @@
               .css('position', 'fixed')
               .css('top', newTop);
 
-            if (typeof s.getWidthFrom !== 'undefined') {
+            if (s.setWidth && typeof s.getWidthFrom !== 'undefined') {
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 


### PR DESCRIPTION
At the moment, a fixed width is set on the "sticky" element. For my use case, this isn't necessary since the CSS continues to set the width correctly when "sticked".

However, the fixed width causes the layout to break when the page is resized since the width isn't recalculated. Adding an option to prevent the width being set sorts out the problem for me.
