### PR TITLE
Floated elements become "unstuck" in certain window size changes

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -60,7 +60,7 @@
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 
-            s.stickyElement.parent().addClass(s.className);
+            s.stickyElement.parent().addClass(s.className).width(s.stickyElement.outerWidth());
             s.currentTop = newTop;
           }
         }


### PR DESCRIPTION
### Observed Behavior

Sticky elements that are floated-right can become "unstuck" when the window is resized.
### Issue

In certain circumstances (I noticed when opening/closing the Chrome Dev Tools), the width of the sticky-wrapper would be set to '0'. The sticky element, would then appear to the side of the expected position (since it was the `wrapper` that was floated, while the sticky element was fixed).
### Solution

Set the width of the `wrapper` element to that of the child in the `scroller` function

```
s.stickyElement.parent().addClass(s.className).width(s.stickyElement.outerWidth());
```
