### PR TITLE
Added the option for getStickyWidth to be a number as well as a jQuery s...

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -57,7 +57,8 @@
               .css('top', newTop);
 
             if (typeof s.getWidthFrom !== 'undefined') {
-              s.stickyElement.css('width', $(s.getWidthFrom).width());
+              var stickyWidth = $.isNumeric(s.getWidthFrom) ? s.getWidthFrom : $(s.getWidthFrom).width();
+              s.stickyElement.css('width', stickyWidth);
             }
 
             s.stickyElement.parent().addClass(s.className);


### PR DESCRIPTION
Where before you could only do this:

$(".stickyelement").sticky({
	topSpacing:0,
	getWidthFrom:$('.someclass')
});

You can now do this:

$(".stickyelement").sticky({
	topSpacing:0,
	getWidthFrom:$('.someclass').outerWidth()
});

Or this too:

$(".stickyelement").sticky({
	topSpacing:0,
	getWidthFrom:300
});