### PR TITLE
Keep element width on stick (useful for responsive)

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -37,6 +37,7 @@
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
             s.stickyElement
+              .css('width', '')
               .css('position', '')
               .css('top', '');
             s.stickyElement.parent().removeClass(s.className);
@@ -53,6 +54,7 @@
           }
           if (s.currentTop != newTop) {
             s.stickyElement
+              .css('width', s.stickyElement.width())
               .css('position', 'fixed')
               .css('top', newTop);
 


### PR DESCRIPTION
On firefox, if I stick a 100% width body div, with a 100% width image inside, image grows while sticking. 
Forcing width fix this behavior. 