### PR TITLE
Update jquery.sticky.js

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -15,6 +15,7 @@
       topSpacing: 0,
       bottomSpacing: 0,
       className: 'is-sticky',
+      wrap: true,
       wrapperClassName: 'sticky-wrapper',
       center: false,
       getWidthFrom: ''
@@ -71,15 +72,23 @@
     },
     methods = {
       init: function(options) {
-        var o = $.extend(defaults, options);
+        var o = $.extend({}, defaults, options);
         return this.each(function() {
           var stickyElement = $(this);
 
-          var stickyId = stickyElement.attr('id');
-          var wrapper = $('<div></div>')
-            .attr('id', stickyId + '-sticky-wrapper')
-            .addClass(o.wrapperClassName);
-          stickyElement.wrapAll(wrapper);
+          if (o.wrap) {
+            var stickyId = stickyElement.attr('id') ? stickyElement.attr('id') : 'node' + sticked.length;
+            var wrapper = $('<div></div>')
+              .attr('id', stickyId + '-sticky-wrapper')
+              .addClass(o.wrapperClassName);
+            stickyElement.wrapAll(wrapper);
+          }
+
+          if (stickyElement.is('tr')) {
+            stickyElement.parents('table').first().find('th, td').each(function() {
+              $(this).width($(this).width());
+            });
+          }
 
           if (o.center) {
             stickyElement.parent().css({width:stickyElement.outerWidth(),marginLeft:"auto",marginRight:"auto"});
@@ -96,6 +105,7 @@
             bottomSpacing: o.bottomSpacing,
             stickyElement: stickyElement,
             currentTop: null,
+            wrap: o.wrap,
             stickyWrapper: stickyWrapper,
             className: o.className,
             getWidthFrom: o.getWidthFrom


### PR DESCRIPTION
If stuck element has no id attribute then generate one.

Added the possibility not to wrap the stuck element, useful to stick table row (tr) element.

If stuck element is a table row (tr) then fix its children width (td and th elements) to keep columns dimension.
