### PR TITLE
Allow stickiness to be turned off or recalculated

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -102,6 +102,24 @@
           });
         });
       },
+      unstick: function(){
+        return this.each(function() {
+
+          var stickyElement = $(this);
+
+          stickyElement.unwrap();
+          stickyElement.attr('style', '');
+            
+          sticked = sticked.filter(function( stickedItem ){
+            return stickedItem.stickyElement[0] != stickyElement[0]; 
+          });
+        });
+      },
+      restick: function() {
+         methods.unstick.apply(this);
+         methods.init.apply(this, arguments);
+         scroller(); 
+      },
       update: scroller
     };
 


### PR DESCRIPTION
# Adds some new functionality
## Remove stickiness

For example, on a progressive layout some elements might be sticky on a large screen but made unsticky if the window is made smaller:

``` .js
$('foo').sticky('unstick');
```
## Reapply stickiness

If the sticky element's size changes, for example because a menu opened, allows the stickiness to be laid out again.

``` .js
$('foo').sticky('restick', options);
```
