### PR TITLE
Removal of the getWidthFrom value upon unstick

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -40,6 +40,7 @@
               .css('position', '')
               .css('top', '');
             s.stickyElement.parent().removeClass(s.className);
+            if(s.getWidthFrom != "") s.stickyElement.css("width","");
             s.currentTop = null;
           }
         }


### PR DESCRIPTION
If the element width had been modified by a reference-element using the getWidthFrom option, this value should be removed upon unsticking the element so that the element readjusts to its natural width.
