### PR TITLE
Use only css to control sticky behavior

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -17,7 +17,8 @@
       className: 'is-sticky',
       wrapperClassName: 'sticky-wrapper',
       center: false,
-      getWidthFrom: ''
+      getWidthFrom: '',
+      useClassOnly: false
     },
     $window = $(window),
     $document = $(document),
@@ -36,9 +37,11 @@
 
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
-            s.stickyElement
-              .css('position', '')
-              .css('top', '');
+            if (!s.useClassOnly) {
+              s.stickyElement
+                .css('position', '')
+                .css('top', '');
+            }
             s.stickyElement.parent().removeClass(s.className);
             s.currentTop = null;
           }
@@ -52,9 +55,11 @@
             newTop = s.topSpacing;
           }
           if (s.currentTop != newTop) {
-            s.stickyElement
-              .css('position', 'fixed')
-              .css('top', newTop);
+            if (!s.useClassOnly) {
+              s.stickyElement
+                .css('position', 'fixed')
+                .css('top', newTop);
+            }
 
             if (typeof s.getWidthFrom !== 'undefined') {
               s.stickyElement.css('width', $(s.getWidthFrom).width());
@@ -98,7 +103,8 @@
             currentTop: null,
             stickyWrapper: stickyWrapper,
             className: o.className,
-            getWidthFrom: o.getWidthFrom
+            getWidthFrom: o.getWidthFrom,
+            useClassOnly: o.useClassOnly
           });
         });
       },


### PR DESCRIPTION
This allows css to fully control behavior and allow more responsive handling via media queries (like a max-height override for landscape mode on iPhones).
