### PR TITLE
update height of sticky element in case of dynamic content

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -34,6 +34,9 @@
           elementTop = s.stickyWrapper.offset().top,
           etse = elementTop - s.topSpacing - extra;
 
+	//update height in case of dynamic content
+	s.stickyWrapper.css('height', s.stickyElement.outerHeight());
+
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
             s.stickyElement


### PR DESCRIPTION
I have sticky tabs that have different height, and when I switch beetwen them I call .sticky('update') and it doesn't work properly. So I fixed this.