### PR TITLE
Update jquery.sticky.js

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -22,7 +22,8 @@
     $window = $(window),
     $document = $(document),
     sticked = [],
-    windowHeight = $window.height(),
+    // Without checking for a loaded body, it is possible to throw an exception when attempting to scroll before the body of the page has been loaded.
+    documentHeight = $('body').length ? $document.height() : 0,
     scroller = function() {
       var scrollTop = $window.scrollTop(),
         documentHeight = $document.height(),


### PR DESCRIPTION
Without checking for a loaded body, it is possible to throw an exception when attempting to scroll before the body of the page has been loaded.
