### PR TITLE
Stop defaults from being overwritten

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -71,7 +71,7 @@
     },
     methods = {
       init: function(options) {
-        var o = $.extend(defaults, options);
+        var o = $.extend({}, defaults, options);
         return this.each(function() {
           var stickyElement = $(this);
 


### PR DESCRIPTION
Commit message:

> ## Stop `$.extend` overwriting `defaults` object.
> 
> When using `$.extend`, the first argument object is altered, and
> since objects are copied by reference in Javascript that means the
> `defaults` object gets changed when it shouldn't and subsequent
> calls to `$().sticky()` will use previous options rather than fresh
> defaults.

More info:

``` js
var defaults = {
  // defaults set in jquery.sticky.js
  topSpacing: 0,
  bottomSpacing: 0,
  className: 'is-sticky',
  wrapperClassName: 'sticky-wrapper',
  center: false,
  getWidthFrom: ''
};
console.log(defaults.center);
// false
var options = {
  // options passed in to $(element).sticky()
  center: true
};
$.extend(defaults, options)
console.log(defaults.center);
// true
// Subsequent sticky calls will be centered.
```
