### PR TITLE
Reset width when being unstuck if it gets set.

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -17,7 +17,7 @@
       className: 'is-sticky',
       wrapperClassName: 'sticky-wrapper',
       center: false,
-      getWidthFrom: ''
+      getWidthFrom: null
     },
     $window = $(window),
     $document = $(document),
@@ -36,9 +36,14 @@
 
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
-            s.stickyElement
-              .css('position', '')
-              .css('top', '');
+            var cssReset = {
+              'position': '',
+              'top': ''
+            };
+            if (s.getWidthFrom !== null) {
+              cssReset['width'] = '';
+            }
+            s.stickyElement.css(cssReset);
             s.stickyElement.parent().removeClass(s.className);
             s.currentTop = null;
           }
@@ -56,7 +61,7 @@
               .css('position', 'fixed')
               .css('top', newTop);
 
-            if (typeof s.getWidthFrom !== 'undefined') {
+            if (s.getWidthFrom !== null) {
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 


### PR DESCRIPTION
Other enhancements:
- Reduce calls to `$.css()` by passing object of properties instead.
- Only run `$(s.getWidthFrom).width()` if `getWidthFrom` has been set. Previously the condition would always return true because the default was empty string.
