### PR TITLE
Position fixed influence the width of an element

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -52,13 +52,13 @@
             newTop = s.topSpacing;
           }
           if (s.currentTop != newTop) {
-            s.stickyElement
-              .css('position', 'fixed')
-              .css('top', newTop);
-
             if (typeof s.getWidthFrom !== 'undefined') {
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
+            
+            s.stickyElement
+              .css('position', 'fixed')
+              .css('top', newTop);
 
             s.stickyElement.parent().addClass(s.className);
             s.currentTop = newTop;


### PR DESCRIPTION
The width of the stickyElement should be set before the position change for fixed.

If the getWidthFrom is the stickyElement itself, the width will be wrong.
