### PR TITLE
Fix invalid metadata: add `ignore` to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,5 +39,6 @@
     "main": "jquery.sticky.js",
     "dependencies": {
         "jquery": null
-    }
+    },
+    "ignore": []
 }


### PR DESCRIPTION
Bower complains about a non-existent `ignore` parameter in the `bower.json`
configuration. Added an empty array for now, but it seems like eventually it
might be better to ignore the example HTML files in the Github repo.
