### PR TITLE
Added compatibility with IE8

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -138,10 +138,19 @@
   // should be more efficient than using $window.scroll(scroller) and $window.resize(resizer):
   if (window.addEventListener) {
     window.addEventListener('scroll', scroller, false);
-    window.addEventListener('resize', resizer, false);
+
+    if (navigator.appVersion.indexOf('MSIE 8.') === -1) {
+      window.addEventListener('resize', resizer, false);
+    } else {
+      window.addEventListener('resize', function() {setTimeout(resizer, 100);}, false)
+    }
   } else if (window.attachEvent) {
     window.attachEvent('onscroll', scroller);
-    window.attachEvent('onresize', resizer);
+    if (navigator.appVersion.indexOf('MSIE 8.') === -1) {
+      window.attachEvent('onresize', resizer);
+    } else {
+      window.attachEvent('onresize', function() {setTimeout(resizer, 100);})
+    }
   }
 
   $.fn.sticky = function(method) {


### PR DESCRIPTION
Sticky currently doesn't support IE8 very well due to IE8's issues with resize functions. 
http://stackoverflow.com/questions/16564123/jquery-width-issues-in-ie-8
I've found a fix for it.

It's cool if you don't want to merge this PR. I was forced to support IE8 and thought others might find this useful.
Thanks!
