### PR TITLE
Use min-height instead of height

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -99,7 +99,7 @@
           }
 
           var stickyWrapper = stickyElement.parent();
-          stickyWrapper.css('height', stickyElement.outerHeight());
+          stickyWrapper.css('min-height', stickyElement.outerHeight());
           sticked.push({
             topSpacing: o.topSpacing,
             bottomSpacing: o.bottomSpacing,


### PR DESCRIPTION
Ensure the sticky element will never overlapse when not sticky.