### PR TITLE
Change order of getWidthFrom calculation to prevent innaccurate widths

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -54,14 +54,14 @@
             newTop = s.topSpacing;
           }
           if (s.currentTop != newTop) {
+            if (typeof s.getWidthFrom !== 'undefined') {
+              s.stickyElement.css('width', $(s.getWidthFrom).width());
+            }
+
             s.stickyElement
               .css('width', s.stickyElement.width())
               .css('position', 'fixed')
               .css('top', newTop);
-
-            if (typeof s.getWidthFrom !== 'undefined') {
-              s.stickyElement.css('width', $(s.getWidthFrom).width());
-            }
 
             s.stickyElement.trigger('sticky-start', [s]).parent().addClass(s.className);
             s.currentTop = newTop;


### PR DESCRIPTION
This is to fix inaccurate widths being applied from getWidthFrom, under specific conditions:

* box-sizing of the container is border-box
* the container has left or right padding

Under these conditions, when the sticky element is changed to position:fixed, it's width becomes equal to the width of the container + left/right padding on the container. This can lead to unexpected widths being applied to the stick element. Calculating the width from getWidthFrom before setting position:fixed fixes this issue.