### PR TITLE
Adding bottom reached events + fix start event flood on bottom limit reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ This is how it works:
 
 - `sticky(options)`: Initializer. `options` is optional.
 - `sticky('update')`: Recalculates the element's position.
- 
+
 ## Events
 
 - `sticky-start`: When the element becomes sticky.
 - `sticky-end`: When the element returns to its original location
+- `sticky-update`: When the element is sticked but position must be updated for constraints reasons
+- `sticky-bottom-reached`: When the element reached the bottom space limit
+- `sticky-end`: When the element unreached the bottom space limit
 
 To subscribe to events use jquery:
 
@@ -59,5 +62,8 @@ To subscribe to events use jquery:
 <script>
   $('#sticker').on('sticky-start', function() { console.log("Started"); });
   $('#sticker').on('sticky-end', function() { console.log("Ended"); });
+  $('#sticker').on('sticky-update', function() { console.log("Update"); });
+  $('#sticker').on('sticky-bottom-reached', function() { console.log("Bottom reached"); });
+  $('#sticker').on('sticky-botton-unreached', function() { console.log("Bottom unreached"); });
 </script>
 ```

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -63,7 +63,21 @@
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 
-            s.stickyElement.trigger('sticky-start', [s]).parent().addClass(s.className);
+            if (s.currentTop === null) {
+              s.stickyElement.trigger('sticky-start', [s]).parent().addClass(s.className);
+            } else {
+              // sticky is started but it have to be repositioned
+              s.stickyElement.trigger('sticky-update', [s]).parent().addClass(s.className);
+            }
+
+            if (s.currentTop === s.topSpacing && s.currentTop > newTop || s.currentTop === null && newTop < s.topSpacing) {
+              // just reached bottom || just started to stick but bottom is already reached
+              s.stickyElement.trigger('sticky-bottom-reached', [s]);
+            } else if(s.currentTop !== null && newTop === s.topSpacing && s.currentTop < newTop) {
+              // sticky is started && sticked at topSpacing && overflowing from top just finished
+              s.stickyElement.trigger('sticky-bottom-unreached', [s]);
+            }
+            
             s.currentTop = newTop;
           }
         }
@@ -86,7 +100,7 @@
           var stickyElement = $(this);
 
           var stickyId = stickyElement.attr('id');
-          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName 
+          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName
           var wrapper = $('<div></div>')
             .attr('id', stickyId + '-sticky-wrapper')
             .addClass(o.wrapperClassName);


### PR DESCRIPTION
Hello,

* `start` event is now triggered only once when the real `start` begins. It was flooding when bottom limit is reached and the `top` css property have to be updated to push up the sticked element.
* To keep the event triggering when `top` is updated after `start`, the `update` event have been added. So it floods like `start` did before.
* `bottom-reached` is triggered when sticked element reached the bottom space limit
* `bottom-unreached` is triggered when sticked element is not reaching the bottom space limit

Hope you will find this usefull...