### PR TITLE
Changed from using .width() to .outerWidth() on one part of the width ch...

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -55,7 +55,7 @@
           }
           if (s.currentTop != newTop) {
             s.stickyElement
-              .css('width', s.stickyElement.width())
+              .css('width', s.stickyElement.outerWidth())
               .css('position', 'fixed')
               .css('top', newTop);
 
@@ -86,7 +86,7 @@
           var stickyElement = $(this);
 
           var stickyId = stickyElement.attr('id');
-          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName 
+          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName
           var wrapper = $('<div></div>')
             .attr('id', stickyId + '-sticky-wrapper')
             .addClass(o.wrapperClassName);


### PR DESCRIPTION
Changed width checking from using .width() to outerWidth() on one part.

Some notes:
I have experienced some of my sidebar items keeps shrinking in width when using `bottomSpacing` values. This element have no fixed width (it expands to suit the container). I noticed that on every scroll up, the width of the item is being shrunk by a few pixels (probably caused by the css borders), until to a point where the width is zero.

Changing the width checking to outerWidth() fixes this for me. Do check if this is appropriate.