### PR TITLE
.widthFromWrapper option added and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Sticky is a jQuery plugin that gives you the ability to make any element on your
 This is how it works:
 
 - When the target element is about to be hidden, the plugin will add the class `className` to it (and to a wrapper added as its parent), set it to `position: fixed` and calculate its new `top`, based on the element's height, the page height and the `topSpacing` and `bottomSpacing` options.
-- That's it. In some cases you might need to set a fixed width to your element when it is "sticked". Check the `example-*.html` files for some examples.
+- That's it. 
+In some cases you might need to set a fixed width to your element when it is "sticked".
+But by default (`widthFromWrapper == true`) sticky updates elements's width to the wrapper's width.
+Check the `example-*.html` files for some examples.
 
 ## Usage
 
@@ -41,6 +44,7 @@ This is how it works:
 - `className`: CSS class added to the element's wrapper when "sticked".
 - `wrapperClassName`: CSS class added to the wrapper.
 - `getWidthFrom`: Selector of element referenced to set fixed width of "sticky" element.
+- `widthFromWrapper`: boolean determining whether width of the "sticky" element should be updated to match the wrapper's width. Wrapper is a placeholder for "sticky" element while it is fixed (out of static elements flow), and it's width depends on the context and CSS rules.
 - `responsiveWidth`: boolean determining whether widths will be recalculated on window resize (using getWidthfrom).
 
 ## Methods

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -21,6 +21,7 @@
       wrapperClassName: 'sticky-wrapper',
       center: false,
       getWidthFrom: '',
+      widthFromWrapper: true,
       responsiveWidth: false
     },
     $window = $(window),
@@ -60,7 +61,13 @@
             newTop = s.topSpacing;
           }
           if (s.currentTop != newTop) {
-            var newWidth = s.getWidthFrom && $(s.getWidthFrom).width() || null;
+            var newWidth;
+            if ( s.getWidthFrom ) {
+                newWidth = $(s.getWidthFrom).width() || null;
+            }
+            else if(s.widthFromWrapper) {
+                newWidth = s.stickyWrapper.width();
+            }
             if ( newWidth == null ) {
                 newWidth = s.stickyElement.width();
             }

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -1,16 +1,19 @@
-// Sticky Plugin v1.0.0 for jQuery
+// Sticky Plugin v1.0.1 for jQuery
 // =============
 // Author: Anthony Garand
 // Improvements by German M. Bravo (Kronuz) and Ruud Kamphuis (ruudk)
 // Improvements by Leonardo C. Daronco (daronco)
 // Created: 2/14/2011
-// Date: 2/12/2012
+// Date: 15/04/2015
 // Website: http://labs.anthonygarand.com/sticky
 // Description: Makes an element on the page stick on the screen as you scroll
 //       It will only set the 'top' and 'position' of your element, you
 //       might need to adjust the width in some cases.
 
 (function($) {
+    var slice = Array.prototype.slice; // save ref to original slice()
+    var splice = Array.prototype.splice; // save ref to original slice()
+
   var defaults = {
       topSpacing: 0,
       bottomSpacing: 0,
@@ -117,19 +120,21 @@
       update: scroller,
       unstick: function(options) {
         return this.each(function() {
-          var unstickyElement = $(this);
+          var that = this;
+          var unstickyElement = $(that);
 
           var removeIdx = -1;
-          for (var i = 0; i < sticked.length; i++)
+          var i = sticked.length;
+          while ( i-- > 0 ) 
           {
-            if (sticked[i].stickyElement.get(0) == unstickyElement.get(0))
+            if (sticked[i].stickyElement.get(0) == that)
             {
+                splice.call(sticked,i,1);
                 removeIdx = i;
             }
           }
           if(removeIdx != -1)
           {
-            sticked.splice(removeIdx,1);
             unstickyElement.unwrap();
             unstickyElement.removeAttr('style');
           }
@@ -148,7 +153,7 @@
 
   $.fn.sticky = function(method) {
     if (methods[method]) {
-      return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
+      return methods[method].apply(this, slice.call(arguments, 1));
     } else if (typeof method === 'object' || !method ) {
       return methods.init.apply( this, arguments );
     } else {
@@ -158,7 +163,7 @@
 
   $.fn.unstick = function(method) {
     if (methods[method]) {
-      return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
+      return methods[method].apply(this, slice.call(arguments, 1));
     } else if (typeof method === 'object' || !method ) {
       return methods.unstick.apply( this, arguments );
     } else {

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -41,9 +41,11 @@
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
             s.stickyElement
-              .css('width', '')
-              .css('position', '')
-              .css('top', '');
+              .css({
+                'width': '',
+                'position': '',
+                'top': ''
+              });
             s.stickyElement.parent().removeClass(s.className);
             s.stickyElement.trigger('sticky-end', [s]);
             s.currentTop = null;
@@ -58,14 +60,14 @@
             newTop = s.topSpacing;
           }
           if (s.currentTop != newTop) {
+            var newWidth = s.getWidthFrom && $(s.getWidthFrom).width() || null;
+            if ( newWidth == null ) {
+                newWidth = s.stickyElement.width();
+            }
             s.stickyElement
-              .css('width', s.stickyElement.width())
+              .css('width', newWidth)
               .css('position', 'fixed')
               .css('top', newTop);
-
-            if ( s.getWidthFrom ) {
-              s.stickyElement.css('width', $(s.getWidthFrom).width());
-            }
 
             s.stickyElement.parent().addClass(s.className);
             s.stickyElement.trigger('sticky-start', [s]);
@@ -138,10 +140,12 @@
           {
             unstickyElement.unwrap();
             unstickyElement
-              .css('width', '')
-              .css('position', '')
-              .css('top', '')
-              .css('float', '')
+              .css({
+                'width': '',
+                'position': '',
+                'top': '',
+                'float': ''
+              })
             ;
           }
         });

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -63,7 +63,7 @@
               .css('position', 'fixed')
               .css('top', newTop);
 
-            if (typeof s.getWidthFrom !== 'undefined') {
+            if ( s.getWidthFrom ) {
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 
@@ -79,7 +79,7 @@
 
       for (var i = 0; i < sticked.length; i++) {
         var s = sticked[i];
-        if (typeof s.getWidthFrom !== 'undefined' && s.responsiveWidth === true) {
+        if ( s.getWidthFrom && s.responsiveWidth === true ) {
           s.stickyElement.css('width', $(s.getWidthFrom).width());
         }
       }

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -128,7 +128,7 @@
           var i = sticked.length;
           while ( i-- > 0 )
           {
-            if (sticked[i].stickyElement.get(0) == that)
+            if (sticked[i].stickyElement.get(0) === that)
             {
                 splice.call(sticked,i,1);
                 removeIdx = i;
@@ -137,7 +137,12 @@
           if(removeIdx != -1)
           {
             unstickyElement.unwrap();
-            unstickyElement.removeAttr('style');
+            unstickyElement
+              .css('width', '')
+              .css('position', '')
+              .css('top', '')
+              .css('float', '')
+            ;
           }
         });
       }

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -44,7 +44,8 @@
               .css('width', '')
               .css('position', '')
               .css('top', '');
-            s.stickyElement.trigger('sticky-end', [s]).parent().removeClass(s.className);
+            s.stickyElement.parent().removeClass(s.className);
+            s.stickyElement.trigger('sticky-end', [s]);
             s.currentTop = null;
           }
         }
@@ -66,7 +67,8 @@
               s.stickyElement.css('width', $(s.getWidthFrom).width());
             }
 
-            s.stickyElement.trigger('sticky-start', [s]).parent().addClass(s.className);
+            s.stickyElement.parent().addClass(s.className);
+            s.stickyElement.trigger('sticky-start', [s]);
             s.currentTop = newTop;
           }
         }

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -110,16 +110,12 @@
           }
 
           stickyWrapper.css('height', stickyHeight);
-          sticked.push({
-            topSpacing: o.topSpacing,
-            bottomSpacing: o.bottomSpacing,
-            stickyElement: stickyElement,
-            currentTop: null,
-            stickyWrapper: stickyWrapper,
-            className: o.className,
-            getWidthFrom: o.getWidthFrom,
-            responsiveWidth: o.responsiveWidth
-          });
+
+          o.stickyElement = stickyElement;
+          o.stickyWrapper = stickyWrapper;
+          o.currentTop    = null;
+
+          sticked.push(o);
         });
       },
       update: scroller,

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -89,22 +89,25 @@
           var stickyElement = $(this);
 
           var stickyId = stickyElement.attr('id');
-          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName 
+          var stickyHeight = stickyElement.outerHeight();
+          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName
           var wrapper = $('<div></div>')
-            .attr('id', stickyId + '-sticky-wrapper')
+            .attr('id', wrapperId)
             .addClass(o.wrapperClassName);
+
           stickyElement.wrapAll(wrapper);
 
+          var stickyWrapper = stickyElement.parent();
+
           if (o.center) {
-            stickyElement.parent().css({width:stickyElement.outerWidth(),marginLeft:"auto",marginRight:"auto"});
+            stickyWrapper.css({width:stickyElement.outerWidth(),marginLeft:"auto",marginRight:"auto"});
           }
 
           if (stickyElement.css("float") == "right") {
             stickyElement.css({"float":"none"}).parent().css({"float":"right"});
           }
 
-          var stickyWrapper = stickyElement.parent();
-          stickyWrapper.css('height', stickyElement.outerHeight());
+          stickyWrapper.css('height', stickyHeight);
           sticked.push({
             topSpacing: o.topSpacing,
             bottomSpacing: o.bottomSpacing,
@@ -125,7 +128,7 @@
 
           var removeIdx = -1;
           var i = sticked.length;
-          while ( i-- > 0 ) 
+          while ( i-- > 0 )
           {
             if (sticked[i].stickyElement.get(0) == that)
             {


### PR DESCRIPTION
I made some improvements to stiky so that it could work in some of my projects.
I didn't change any of the old functionality.

The new option `.widthFromWrapper` enables me to handle width of the wrapper with pure CSS and sticky just adjusts it's width accordingly, without any extra coding.