### PR TITLE
Added option to follow horizontal scrollbar movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ This is how it works:
 - `wrapperClassName`: CSS class added to the wrapper.
 - `getWidthFrom`: Selector of element referenced to set fixed width of "sticky" element.
 - `responsiveWidth`: boolean determining whether widths will be recalculated on window resize (using getWidthfrom).
+- `followHorizontalScroll`: Boolean telling to sticked element to follow horizontal scrollbar movement instead of staying fixed
 
 ## Methods
 
 - `sticky(options)`: Initializer. `options` is optional.
 - `sticky('update')`: Recalculates the element's position.
- 
+
 ## Events
 
 - `sticky-start`: When the element becomes sticky.

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -109,12 +109,11 @@
             s.stickyElement.css('width', newWidth);
         }
 
-        if (s.followHorizontalScroll && s.stickyElement.css('position') === 'fixed') {
-          var newLeft = s.stickyWrapper.offset().left;
-          if (newLeft !== s.leftPosition) {
-            s.leftPosition = newLeft;
-            scroller();
-          }
+        if (s.followHorizontalScroll) {
+            s.leftPosition = s.stickyWrapper.offset().left;
+            if (s.stickyElement.css('position') === 'fixed') {
+              scroller();
+            }
         }
       }
     },

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -119,7 +119,7 @@
             className: o.className,
             getWidthFrom: o.getWidthFrom,
             responsiveWidth: o.responsiveWidth,
-            leftPosition: stickyElement.offset().left,
+            leftPosition: stickyWrapper.offset().left,
             followHorizontalScroll: o.followHorizontalScroll
           });
         });

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -18,7 +18,8 @@
       wrapperClassName: 'sticky-wrapper',
       center: false,
       getWidthFrom: '',
-      responsiveWidth: false
+      responsiveWidth: false,
+      followHorizontalScroll: false
     },
     $window = $(window),
     $document = $(document),
@@ -28,7 +29,8 @@
       var scrollTop = $window.scrollTop(),
         documentHeight = $document.height(),
         dwh = documentHeight - windowHeight,
-        extra = (scrollTop > dwh) ? dwh - scrollTop : 0;
+        extra = (scrollTop > dwh) ? dwh - scrollTop : 0,
+        scrollLeft = $window.scrollLeft();
 
       for (var i = 0; i < sticked.length; i++) {
         var s = sticked[i],
@@ -40,14 +42,17 @@
             s.stickyElement
               .css('width', '')
               .css('position', '')
-              .css('top', '');
+              .css('top', '')
+              .css('left', '');
             s.stickyElement.trigger('sticky-end', [s]).parent().removeClass(s.className);
             s.currentTop = null;
+            s.currentLeft = null;
           }
         }
         else {
           var newTop = documentHeight - s.stickyElement.outerHeight()
             - s.topSpacing - s.bottomSpacing - scrollTop - extra;
+          var newLeft = s.leftPosition - scrollLeft;
           if (newTop < 0) {
             newTop = newTop + s.topSpacing;
           } else {
@@ -65,6 +70,9 @@
 
             s.stickyElement.trigger('sticky-start', [s]).parent().addClass(s.className);
             s.currentTop = newTop;
+          }
+          if (s.followHorizontalScroll && newLeft !== s.currentLeft && s.stickyElement.css('position') === 'fixed') {
+            s.stickyElement.css('left', newLeft);
           }
         }
       }
@@ -86,7 +94,7 @@
           var stickyElement = $(this);
 
           var stickyId = stickyElement.attr('id');
-          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName 
+          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName
           var wrapper = $('<div></div>')
             .attr('id', stickyId + '-sticky-wrapper')
             .addClass(o.wrapperClassName);
@@ -110,7 +118,9 @@
             stickyWrapper: stickyWrapper,
             className: o.className,
             getWidthFrom: o.getWidthFrom,
-            responsiveWidth: o.responsiveWidth
+            responsiveWidth: o.responsiveWidth,
+            leftPosition: stickyElement.offset().left,
+            followHorizontalScroll: o.followHorizontalScroll
           });
         });
       },

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -108,6 +108,14 @@
         if ( newWidth != null ) {
             s.stickyElement.css('width', newWidth);
         }
+
+        if (s.followHorizontalScroll && s.stickyElement.css('position') === 'fixed') {
+          var newLeft = s.stickyWrapper.offset().left;
+          if (newLeft !== s.leftPosition) {
+            s.leftPosition = newLeft;
+            scroller();
+          }
+        }
       }
     },
     methods = {


### PR DESCRIPTION
Sticked element can now follow horizontal scrollbar movement instead of staying fixed.

If the scrollbar goes 50px to the right, the sticked element will go 50px to left and will mimic a normal element positionning with that `position: fixed` element.
