### PR TITLE
Add package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.psd
 *~
+node_modules/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "jquery-sticky",
+  "version": "1.0.3",
+  "description": "Sticky is a jQuery plugin that gives you the ability to make any element on your page always stay visible.",
+  "main": "jquery.sticky.js",
+  "files": [
+    "jquery.sticky.js"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "garand/sticky",
+  "keywords": [
+    "dom",
+    "jquery-plugin",
+    "ui"
+  ],
+  "author": "Anthony Garand",
+  "license": "(MIT OR GPL-3.0)",
+  "bugs": {
+    "url": "https://github.com/garand/sticky/issues"
+  },
+  "homepage": "https://github.com/garand/sticky#readme",
+  "dependencies": {
+    "jquery": "*"
+  }
+}


### PR DESCRIPTION
As the jQuery plugin repo is read-only, the recommended way of distribution is npm. (https://plugins.jquery.com/)

Adding this allows us to install from GitHub using npm. If you would publish it (`npm publish`), even better :smile: 
This needs #170 to work properly in node-land, but not strictly required.

I copied most of the content from `bower.json`. The only thing is which jquery-versions do you support? RIght now it's anything goes.