### PR TITLE
Make sticky element stick to bottom of wrapper when reached

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -50,8 +50,8 @@
           elementTop = s.stickyWrapper.offset().top,
           etse = elementTop - s.topSpacing - extra;
 
-	//update height in case of dynamic content
-	s.stickyWrapper.css('height', s.stickyElement.outerHeight());
+        //update height in case of dynamic content
+        s.stickyWrapper.css('height', s.stickyElement.outerHeight());
 
         if (scrollTop <= etse) {
           if (s.currentTop !== null) {
@@ -110,8 +110,10 @@
           }
 
           // Check if sticky has reached end of container and stop sticking
-          var stickyHeight = s.stickyElement.outerHeight();
-          if( -1*(s.stickyWrapper.offset().top + s.stickyWrapper.outerHeight()) > stickyHeight + s.topSpacing ) {
+          var stickyWrapperContainer = s.stickyWrapper.parent();
+          var unstick = (s.stickyElement.offset().top + s.stickyElement.outerHeight() >= stickyWrapperContainer.offset().top + stickyWrapperContainer.outerHeight()) && (s.stickyElement.offset().top <= s.topSpacing);
+
+          if( unstick ) {
             s.stickyElement
               .css('position', 'absolute')
               .css('top', '')

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -108,6 +108,20 @@
 
             s.currentTop = newTop;
           }
+
+          // Check if sticky has reached end of container and stop sticking
+          var stickyHeight = s.stickyElement.outerHeight();
+          if( -1*(s.stickyWrapper.offset().top + s.stickyWrapper.outerHeight()) > stickyHeight + s.topSpacing ) {
+            s.stickyElement
+              .css('position', 'absolute')
+              .css('top', '')
+              .css('bottom', 0);
+          } else {
+            s.stickyElement
+              .css('position', 'fixed')
+              .css('top', newTop)
+              .css('bottom', '');
+          }
         }
       }
     },


### PR DESCRIPTION
Checks if sticky element has reached bottom of its wrapper, and makes it stick to the bottom instead of overflowing.

The caveat is that the script **checks on every scroll event** if this condition happens and then **always applies css styles** to the element.

It's not the most elegant solution but it works, and at least is a good start.

Solves #164, #127 and maybe #106.