### PR TITLE
depend on jquery with a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/garand/sticky/issues"
   },
   "homepage": "https://github.com/garand/sticky#readme",
-  "dependencies": {
+  "peerDependencies": {
     "jquery": "*"
   }
 }


### PR DESCRIPTION
@garand Otherwise you get cases where this module depends on a different version of jQuery than the parent package

https://nodejs.org/en/blog/npm/peer-dependencies/#the-problem-plugins