### PR TITLE
Return sticky-wrapper initial height on unstick

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -61,7 +61,9 @@
                 'position': '',
                 'top': ''
               });
-            s.stickyElement.parent().removeClass(s.className);
+            s.stickyElement.parent()
+              .css('height','')
+              .removeClass(s.className);
             s.stickyElement.trigger('sticky-end', [s]);
             s.currentTop = null;
           }


### PR DESCRIPTION
As a case: I change styles for sticky content which affect its height. Thus on unstick the content overlaps the next block. This patch fixes this behaviour.
