### PR TITLE
Sizes may have changed in response to the window size change

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -144,6 +144,9 @@
             s.stickyElement.css('width', newWidth);
         }
       }
+      
+      // Sizes may have changed in response to the window size change
+      scroller();
     },
     methods = {
       init: function(options) {


### PR DESCRIPTION
This only adds a `scroller()` update in case of window resize - because `scroller()` updates the wrapper height, and that height may have been changed in response to the window's width change.