### PR TITLE
Adding scroller call on resize

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -243,9 +243,11 @@
   // should be more efficient than using $window.scroll(scroller) and $window.resize(resizer):
   if (window.addEventListener) {
     window.addEventListener('scroll', scroller, false);
+    window.addEventListener('resize', scroller, false);
     window.addEventListener('resize', resizer, false);
   } else if (window.attachEvent) {
     window.attachEvent('onscroll', scroller);
+    window.attachEvent('onresize', scroller);
     window.attachEvent('onresize', resizer);
   }
 


### PR DESCRIPTION
When resizing window the element does not stick if it goes above the top of the browser.

I added the double call, there may be a more elegant way to fix this, but this resolved the issue for me.