### PR TITLE
If window is resized the #sticky-wrapper element will be wrapped by i…

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -162,7 +162,11 @@
             .attr('id', wrapperId)
             .addClass(o.wrapperClassName);
 
-          stickyElement.wrapAll(wrapper);
+          stickyElement.wrapAll(function() {
+            if ($(this).parent("#" + wrapperId).length == 0) {
+                    return wrapper;
+            }
+});
 
           var stickyWrapper = stickyElement.parent();
 


### PR DESCRIPTION
…tself again

This fixes that behavior.