### PR TITLE
 add backgroundColor api to enable sticky background-color changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check the `example-*.html` files for some examples.
 - `widthFromWrapper`: (default: `true`) Boolean determining whether width of the "sticky" element should be updated to match the wrapper's width. Wrapper is a placeholder for "sticky" element while it is fixed (out of static elements flow), and its width depends on the context and CSS rules. Works only as long `getWidthForm` isn't set.
 - `responsiveWidth`: (default: `false`) Boolean determining whether widths will be recalculated on window resize (using getWidthfrom).
 - `zIndex`: (default: `auto`) controls z-index of the sticked element.
+- `backgroundColor`: (default: ``) controls background-color of the sticked element.
 
 ## Methods
 

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -34,7 +34,8 @@
       getWidthFrom: '',
       widthFromWrapper: true, // works only when .getWidthFrom is empty
       responsiveWidth: false,
-      zIndex: 'auto'
+      zIndex: 'auto',
+      backgroundColor: ''
     },
     $window = $(window),
     $document = $(document),
@@ -61,7 +62,8 @@
                 'width': '',
                 'position': '',
                 'top': '',
-                'z-index': ''
+                'z-index': '',
+                'background-color': ''
               });
             s.stickyElement.parent().removeClass(s.className);
             s.stickyElement.trigger('sticky-end', [s]);
@@ -90,7 +92,8 @@
               .css('width', newWidth)
               .css('position', 'fixed')
               .css('top', newTop)
-              .css('z-index', s.zIndex);
+              .css('z-index', s.zIndex)
+              .css('background-color', s.backgroundColor);
 
             s.stickyElement.parent().addClass(s.className);
 
@@ -121,13 +124,15 @@
               .css('position', 'absolute')
               .css('top', '')
               .css('bottom', 0)
-              .css('z-index', '');
+              .css('z-index', '')
+              .css('background-color', '');
           } else {
             s.stickyElement
               .css('position', 'fixed')
               .css('top', newTop)
               .css('bottom', '')
-              .css('z-index', s.zIndex);
+              .css('z-index', s.zIndex)
+              .css('background-color', s.backgroundColor);
           }
         }
       }


### PR DESCRIPTION
Sometimes people want to change the sticky bars' background-color when scrolling to the top.
`$("#header").sticky({ topSpacing: 0, backgroundColor: '#f8f8f8' });` exposed the backgroundColor api to sticky users.