### PR TITLE
Fix MSEdge where element offset.top is negative

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -48,7 +48,7 @@
 
       for (var i = 0, l = sticked.length; i < l; i++) {
         var s = sticked[i],
-          elementTop = s.stickyWrapper.offset().top,
+          elementTop = parseInt(s.stickyWrapper.offset().top, 10),
           etse = elementTop - s.topSpacing - extra;
 
         //update height in case of dynamic content


### PR DESCRIPTION
When sticky at the top of the page the element top can be a negative float (i.e. -0.17). This seems only to happen in MSEdge. This broke removing the sticky class.

See also
https://jsfiddle.net/19ge6hn4/1/
