### PR TITLE
Fix init on jquery multiple element

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -152,8 +152,8 @@
     },
     methods = {
       init: function(options) {
-        var o = $.extend({}, defaults, options);
         return this.each(function() {
+          var o = $.extend({}, defaults, options);
           var stickyElement = $(this);
 
           var stickyId = stickyElement.attr('id');


### PR DESCRIPTION
If initiating like that **$('*[sticky]').sticky();** and Jquery selector returns more that 1 objects, then options from each next object rewrites prev. one. And if init inside of **this.each()** loop - all work fine.