### PR TITLE
allows dev to attach scroll listener to specific element

### DIFF
--- a/example-center.html
+++ b/example-center.html
@@ -2,13 +2,8 @@
 <html>
 <head>
   <title>Sticky Plugin</title>
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script type="text/javascript" src="jquery.sticky.js"></script>
-  <script>
-    $(window).load(function(){
-      $("#sticker").sticky({ topSpacing: 0, center:true, className:"hey" });
-    });
-  </script>
   <style>
     body {
       height: 10000px;
@@ -38,5 +33,10 @@
     <p>This is the sticky thingy that is really cool.</p>
   </div>
   <p>This is test this is text this is text at the bottom.</p>
+  <script>
+    $(function(){
+      $("#sticker").sticky({ topSpacing: 0, center:true, className:"hey" });
+    });
+  </script>
 </body>
 </html>

--- a/example-custom-scroller.html
+++ b/example-custom-scroller.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+<head>
+  <title>Sticky Plugin</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script type="text/javascript" src="jquery.sticky.js"></script>
+  <style>
+    body {
+      height: 10000px;
+      padding: 0;
+      margin: 0;
+    }
+
+    p {
+      padding: 10px;
+    }
+
+    #scroller {
+      height: 500px;
+      overflow: auto;
+      background-color: cyan;
+    }
+
+    #scrollee {
+      height: 10000px;
+      padding: 0;
+      margin: 0;
+    }
+
+    #sticker {
+      background: #bada55;
+      color: white;
+      width: 300px;
+      font-family: Droid Sans;
+      font-size: 40px;
+      line-height: 1.6em;
+      font-weight: bold;
+      text-align: center;
+      padding: 20px;
+      margin: 0 auto;
+      text-shadow: 0 1px 1px rgba(0,0,0,.2);
+      border-radius: 50px;
+    }
+  </style>
+</head>
+<body>
+  <p>
+    In this example the dev has defined a specific scrollable area (the light-blue one)
+    <br>
+    The element will stick only when the user scrolls inside that specified area.
+  </p>
+  <div id="scroller">
+    <div id="scrollee">
+      <p>This is test this is text this is text at the top.</p>
+      <div id="sticker">
+        <p>This is the sticky thingy that is really cool.</p>
+      </div>
+      <p>This is test this is text this is text at the bottom.</p>
+    </div>
+  </div>
+  <script>
+    $(function(){
+      $("#sticker").sticky({
+        topSpacing: 0,
+        center:true,
+        className:"hey",
+        scroller: document.getElementById('scroller')
+      });
+    });
+  </script>
+</body>
+</html>

--- a/example-header.html
+++ b/example-header.html
@@ -2,13 +2,8 @@
 <html>
 <head>
   <title>Sticky Plugin</title>
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script type="text/javascript" src="jquery.sticky.js"></script>
-  <script>
-    $(window).load(function(){
-      $("#header").sticky({ topSpacing: 0 });
-    });
-  </script>
   <style>
     body {
       height: 10000px;
@@ -37,5 +32,10 @@
     <p>This is the sticky thingy that is really cool.</p>
   </div>
   <p>This is test this is text this is text at the bottom.</p>
+  <script>
+    $(function(){
+      $("#header").sticky({ topSpacing: 0 });
+    });
+  </script>
 </body>
 </html>

--- a/example-right.html
+++ b/example-right.html
@@ -2,13 +2,8 @@
 <html>
 <head>
   <title>Sticky Plugin</title>
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script type="text/javascript" src="jquery.sticky.js"></script>
-  <script>
-    $(window).load(function(){
-      $("#sticker").sticky({ topSpacing: 50 });
-    });
-  </script>
   <style>
     body {
       height: 10000px;
@@ -45,5 +40,10 @@
     </div>
     <p>This is test this is text this is text at the bottom.</p>
   </div>
+  <script>
+    $(function(){
+      $("#sticker").sticky({ topSpacing: 50 });
+    });
+  </script>
 </body>
 </html>

--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -9,265 +9,305 @@
 // Description: Makes an element on the page stick on the screen as you scroll
 //              It will only set the 'top' and 'position' of your element, you
 //              might need to adjust the width in some cases.
-
-(function (factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['jquery'], factory);
-    } else if (typeof module === 'object' && module.exports) {
-        // Node/CommonJS
-        module.exports = factory(require('jquery'));
-    } else {
-        // Browser globals
-        factory(jQuery);
-    }
-}(function ($) {
-    var slice = Array.prototype.slice; // save ref to original slice()
-    var splice = Array.prototype.splice; // save ref to original slice()
+(function(factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node/CommonJS
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function($) {
+  var slice = Array.prototype.slice; // save ref to original slice()
+  var splice = Array.prototype.splice; // save ref to original slice()
 
   var defaults = {
-      topSpacing: 0,
-      bottomSpacing: 0,
-      className: 'is-sticky',
-      wrapperClassName: 'sticky-wrapper',
-      center: false,
-      getWidthFrom: '',
-      widthFromWrapper: true, // works only when .getWidthFrom is empty
-      responsiveWidth: false,
-      zIndex: 'inherit'
-    },
-    $window = $(window),
-    $document = $(document),
-    sticked = [],
-    windowHeight = $window.height(),
-    scroller = function() {
-      var scrollTop = $window.scrollTop(),
+    topSpacing: 0,
+    bottomSpacing: 0,
+    className: 'is-sticky',
+    wrapperClassName: 'sticky-wrapper',
+    center: false,
+    getWidthFrom: '',
+    widthFromWrapper: true, // works only when .getWidthFrom is empty
+    responsiveWidth: false,
+    zIndex: 'inherit'
+  };
+
+  var $window = $(window);
+  var $document = $(document);
+  var sticked = {};
+  var windowHeight = $window.height();
+
+  var scroller = function(eventOrStickyElement) {
+    var s;
+
+    if (eventOrStickyElement &&
+        eventOrStickyElement.handleObj &&
+        eventOrStickyElement.handleObj.namespace) { // is event
+      s = sticked[eventOrStickyElement.handleObj.namespace];
+    } else if (eventOrStickyElement && eventOrStickyElement.nodeType) { // is StickyElement
+      var $wrapper = $(eventOrStickyElement).parent();
+      if ($wrapper) {
+        s = sticked[$wrapper.attr('id')];
+      }
+    }
+
+    if (!s) {
+      return;
+    }
+
+    var scrollTop = $window.scrollTop(),
         documentHeight = $document.height(),
         dwh = documentHeight - windowHeight,
         extra = (scrollTop > dwh) ? dwh - scrollTop : 0;
 
-      for (var i = 0, l = sticked.length; i < l; i++) {
-        var s = sticked[i],
-          elementTop = s.stickyWrapper.offset().top,
-          etse = elementTop - s.topSpacing - extra;
+    var elementTop = s.stickyWrapper.offset().top,
+        etse = elementTop - s.topSpacing - extra;
 
-        //update height in case of dynamic content
-        s.stickyWrapper.css('height', s.stickyElement.outerHeight());
+    //update height in case of dynamic content
+    s.stickyWrapper.css('height', s.stickyElement.outerHeight());
 
-        if (scrollTop <= etse) {
-          if (s.currentTop !== null) {
-            s.stickyElement
-              .css({
-                'width': '',
-                'position': '',
-                'top': '',
-                'z-index': ''
-              });
-            s.stickyElement.parent().removeClass(s.className);
-            s.stickyElement.trigger('sticky-end', [s]);
-            s.currentTop = null;
-          }
-        }
-        else {
-          var newTop = documentHeight - s.stickyElement.outerHeight()
-            - s.topSpacing - s.bottomSpacing - scrollTop - extra;
-          if (newTop < 0) {
-            newTop = newTop + s.topSpacing;
-          } else {
-            newTop = s.topSpacing;
-          }
-          if (s.currentTop !== newTop) {
-            var newWidth;
-            if (s.getWidthFrom) {
-                padding =  s.stickyElement.innerWidth() - s.stickyElement.width();
-                newWidth = $(s.getWidthFrom).width() - padding || null;
-            } else if (s.widthFromWrapper) {
-                newWidth = s.stickyWrapper.width();
-            }
-            if (newWidth == null) {
-                newWidth = s.stickyElement.width();
-            }
-            s.stickyElement
-              .css('width', newWidth)
-              .css('position', 'fixed')
-              .css('top', newTop)
-              .css('z-index', s.zIndex);
-
-            s.stickyElement.parent().addClass(s.className);
-
-            if (s.currentTop === null) {
-              s.stickyElement.trigger('sticky-start', [s]);
-            } else {
-              // sticky is started but it have to be repositioned
-              s.stickyElement.trigger('sticky-update', [s]);
-            }
-
-            if (s.currentTop === s.topSpacing && s.currentTop > newTop || s.currentTop === null && newTop < s.topSpacing) {
-              // just reached bottom || just started to stick but bottom is already reached
-              s.stickyElement.trigger('sticky-bottom-reached', [s]);
-            } else if(s.currentTop !== null && newTop === s.topSpacing && s.currentTop < newTop) {
-              // sticky is started && sticked at topSpacing && overflowing from top just finished
-              s.stickyElement.trigger('sticky-bottom-unreached', [s]);
-            }
-
-            s.currentTop = newTop;
-          }
-
-          // Check if sticky has reached end of container and stop sticking
-          var stickyWrapperContainer = s.stickyWrapper.parent();
-          var unstick = (s.stickyElement.offset().top + s.stickyElement.outerHeight() >= stickyWrapperContainer.offset().top + stickyWrapperContainer.outerHeight()) && (s.stickyElement.offset().top <= s.topSpacing);
-
-          if( unstick ) {
-            s.stickyElement
-              .css('position', 'absolute')
-              .css('top', '')
-              .css('bottom', 0)
-              .css('z-index', '');
-          } else {
-            s.stickyElement
-              .css('position', 'fixed')
-              .css('top', newTop)
-              .css('bottom', '')
-              .css('z-index', s.zIndex);
-          }
-        }
-      }
-    },
-    resizer = function() {
-      windowHeight = $window.height();
-
-      for (var i = 0, l = sticked.length; i < l; i++) {
-        var s = sticked[i];
-        var newWidth = null;
-        if (s.getWidthFrom) {
-            if (s.responsiveWidth) {
-                newWidth = $(s.getWidthFrom).width();
-            }
-        } else if(s.widthFromWrapper) {
-            newWidth = s.stickyWrapper.width();
-        }
-        if (newWidth != null) {
-            s.stickyElement.css('width', newWidth);
-        }
-      }
-    },
-    methods = {
-      init: function(options) {
-        return this.each(function() {
-          var o = $.extend({}, defaults, options);
-          var stickyElement = $(this);
-
-          var stickyId = stickyElement.attr('id');
-          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName;
-          var wrapper = $('<div></div>')
-            .attr('id', wrapperId)
-            .addClass(o.wrapperClassName);
-
-          stickyElement.wrapAll(function() {
-            if ($(this).parent("#" + wrapperId).length == 0) {
-                    return wrapper;
-            }
-});
-
-          var stickyWrapper = stickyElement.parent();
-
-          if (o.center) {
-            stickyWrapper.css({width:stickyElement.outerWidth(),marginLeft:"auto",marginRight:"auto"});
-          }
-
-          if (stickyElement.css("float") === "right") {
-            stickyElement.css({"float":"none"}).parent().css({"float":"right"});
-          }
-
-          o.stickyElement = stickyElement;
-          o.stickyWrapper = stickyWrapper;
-          o.currentTop    = null;
-
-          sticked.push(o);
-
-          methods.setWrapperHeight(this);
-          methods.setupChangeListeners(this);
-        });
-      },
-
-      setWrapperHeight: function(stickyElement) {
-        var element = $(stickyElement);
-        var stickyWrapper = element.parent();
-        if (stickyWrapper) {
-          stickyWrapper.css('height', element.outerHeight());
-        }
-      },
-
-      setupChangeListeners: function(stickyElement) {
-        if (window.MutationObserver) {
-          var mutationObserver = new window.MutationObserver(function(mutations) {
-            if (mutations[0].addedNodes.length || mutations[0].removedNodes.length) {
-              methods.setWrapperHeight(stickyElement);
-            }
+    if (scrollTop <= etse) {
+      if (s.currentTop !== null) {
+        s.stickyElement
+          .css({
+            'width': '',
+            'position': '',
+            'top': '',
+            'z-index': ''
           });
-          mutationObserver.observe(stickyElement, {subtree: true, childList: true});
-        } else {
-          if (window.addEventListener) {
-            stickyElement.addEventListener('DOMNodeInserted', function() {
-              methods.setWrapperHeight(stickyElement);
-            }, false);
-            stickyElement.addEventListener('DOMNodeRemoved', function() {
-              methods.setWrapperHeight(stickyElement);
-            }, false);
-          } else if (window.attachEvent) {
-            stickyElement.attachEvent('onDOMNodeInserted', function() {
-              methods.setWrapperHeight(stickyElement);
-            });
-            stickyElement.attachEvent('onDOMNodeRemoved', function() {
-              methods.setWrapperHeight(stickyElement);
-            });
-          }
+        s.stickyElement.parent().removeClass(s.className);
+        s.stickyElement.trigger('sticky-end', [s]);
+        s.currentTop = null;
+      }
+    } else {
+      var newTop = documentHeight - s.stickyElement.outerHeight() -
+        s.topSpacing - s.bottomSpacing - scrollTop - extra;
+      if (newTop < 0) {
+        newTop = newTop + s.topSpacing;
+      } else {
+        newTop = s.topSpacing;
+      }
+      if (s.currentTop !== newTop) {
+        var newWidth;
+        if (s.getWidthFrom) {
+          padding = s.stickyElement.innerWidth() - s.stickyElement.width();
+          newWidth = $(s.getWidthFrom).width() - padding || null;
+        } else if (s.widthFromWrapper) {
+          newWidth = s.stickyWrapper.width();
         }
-      },
-      update: scroller,
-      unstick: function(options) {
-        return this.each(function() {
-          var that = this;
-          var unstickyElement = $(that);
+        if (newWidth == null) {
+          newWidth = s.stickyElement.width();
+        }
+        s.stickyElement
+          .css('width', newWidth)
+          .css('position', 'fixed')
+          .css('top', newTop)
+          .css('z-index', s.zIndex);
 
-          var removeIdx = -1;
-          var i = sticked.length;
-          while (i-- > 0) {
-            if (sticked[i].stickyElement.get(0) === that) {
-                splice.call(sticked,i,1);
-                removeIdx = i;
-            }
-          }
-          if(removeIdx !== -1) {
-            unstickyElement.unwrap();
-            unstickyElement
-              .css({
-                'width': '',
-                'position': '',
-                'top': '',
-                'float': '',
-                'z-index': ''
-              })
-            ;
+        s.stickyElement.parent().addClass(s.className);
+
+        if (s.currentTop === null) {
+          s.stickyElement.trigger('sticky-start', [s]);
+        } else {
+          // sticky is started but it have to be repositioned
+          s.stickyElement.trigger('sticky-update', [s]);
+        }
+
+        if (s.currentTop === s.topSpacing && s.currentTop > newTop || s.currentTop === null && newTop < s.topSpacing) {
+          // just reached bottom || just started to stick but bottom is already reached
+          s.stickyElement.trigger('sticky-bottom-reached', [s]);
+        } else if (s.currentTop !== null && newTop === s.topSpacing && s.currentTop < newTop) {
+          // sticky is started && sticked at topSpacing && overflowing from top just finished
+          s.stickyElement.trigger('sticky-bottom-unreached', [s]);
+        }
+
+        s.currentTop = newTop;
+      }
+
+      // Check if sticky has reached end of container and stop sticking
+      var stickyWrapperContainer = s.stickyWrapper.parent();
+      var unstick = (s.stickyElement.offset().top + s.stickyElement.outerHeight() >= stickyWrapperContainer.offset().top + stickyWrapperContainer.outerHeight()) && (s.stickyElement.offset().top <= s.topSpacing);
+
+      if (unstick) {
+        s.stickyElement
+          .css('position', 'absolute')
+          .css('top', '')
+          .css('bottom', 0)
+          .css('z-index', '');
+      } else {
+        s.stickyElement
+          .css('position', 'fixed')
+          .css('top', newTop)
+          .css('bottom', '')
+          .css('z-index', s.zIndex);
+      }
+    }
+  };
+
+  var resizer = function() {
+    windowHeight = $window.height();
+
+    for (var wrapperId in sticked) {
+      var s = sticked[wrapperId];
+      var newWidth = null;
+      if (s.getWidthFrom) {
+        if (s.responsiveWidth) {
+          newWidth = $(s.getWidthFrom).width();
+        }
+      } else if (s.widthFromWrapper) {
+        newWidth = s.stickyWrapper.width();
+      }
+      if (newWidth != null) {
+        s.stickyElement.css('width', newWidth);
+      }
+    }
+  };
+
+  var methods = {
+    init: function(options) {
+      return this.each(function() {
+        var o = $.extend({}, defaults, options);
+        var stickyElement = $(this);
+
+        var stickyId = stickyElement.attr('id');
+        var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : methods.guid();
+        if (sticked[wrapperId]) {
+          wrapperId = methods.guid();
+        }
+        var wrapper = $('<div></div>')
+          .attr('id', wrapperId)
+          .addClass(o.wrapperClassName);
+
+        stickyElement.wrapAll(function() {
+          if ($(this).parent("#" + wrapperId).length == 0) {
+            return wrapper;
           }
         });
-      }
-    };
 
-  // should be more efficient than using $window.scroll(scroller) and $window.resize(resizer):
+        var stickyWrapper = stickyElement.parent();
+
+        if (o.center) {
+          stickyWrapper.css({
+            width: stickyElement.outerWidth(),
+            marginLeft: "auto",
+            marginRight: "auto"
+          });
+        }
+
+        if (stickyElement.css("float") === "right") {
+          stickyElement.css({
+            "float": "none"
+          }).parent().css({
+            "float": "right"
+          });
+        }
+
+        o.stickyElement = stickyElement;
+        o.stickyWrapper = stickyWrapper;
+        o.currentTop = null;
+        o.scrollEvent = 'scroll.' + wrapperId;
+
+        sticked[wrapperId] = o;
+
+        methods.setWrapperHeight(this);
+        methods.setupChangeListeners(this);
+
+        // add scroll listener for this element
+        $(options.scroller || window).on(o.scrollEvent, scroller);
+      });
+    },
+
+    setWrapperHeight: function(stickyElement) {
+      var element = $(stickyElement);
+      var stickyWrapper = element.parent();
+      if (stickyWrapper) {
+        stickyWrapper.css('height', element.outerHeight());
+      }
+    },
+
+    setupChangeListeners: function(stickyElement) {
+      if (window.MutationObserver) {
+        var mutationObserver = new window.MutationObserver(function(mutations) {
+          if (mutations[0].addedNodes.length || mutations[0].removedNodes.length) {
+            methods.setWrapperHeight(stickyElement);
+          }
+        });
+        mutationObserver.observe(stickyElement, {
+          subtree: true,
+          childList: true
+        });
+      } else {
+        if (window.addEventListener) {
+          stickyElement.addEventListener('DOMNodeInserted', function() {
+            methods.setWrapperHeight(stickyElement);
+          }, false);
+          stickyElement.addEventListener('DOMNodeRemoved', function() {
+            methods.setWrapperHeight(stickyElement);
+          }, false);
+        } else if (window.attachEvent) {
+          stickyElement.attachEvent('onDOMNodeInserted', function() {
+            methods.setWrapperHeight(stickyElement);
+          });
+          stickyElement.attachEvent('onDOMNodeRemoved', function() {
+            methods.setWrapperHeight(stickyElement);
+          });
+        }
+      }
+    },
+
+    update: function() {
+      scroller(this);
+    },
+
+    unstick: function(options) {
+      return this.each(function() {
+        var that = this;
+        var unstickyElement = $(that);
+        var wrapperId = unstickyElement.parent().attr('id');
+        var scrollEvent = sticked[wrapperId].scrollEvent;
+        var scrollArea = sticked[wrapperId].scroller;
+
+        // remove scroll listener for this element
+        $(scrollArea || window).off(scrollEvent, scroller);
+
+        delete sticked[wrapperId];
+
+        unstickyElement.unwrap();
+        unstickyElement
+          .css({
+            'width': '',
+            'position': '',
+            'top': '',
+            'float': '',
+            'z-index': ''
+          });
+      });
+    },
+
+    guid() {
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+      });
+    }
+  };
+
+  // should be more efficient than using $window.resize(resizer):
   if (window.addEventListener) {
-    window.addEventListener('scroll', scroller, false);
     window.addEventListener('resize', resizer, false);
   } else if (window.attachEvent) {
-    window.attachEvent('onscroll', scroller);
     window.attachEvent('onresize', resizer);
   }
 
   $.fn.sticky = function(method) {
     if (methods[method]) {
       return methods[method].apply(this, slice.call(arguments, 1));
-    } else if (typeof method === 'object' || !method ) {
-      return methods.init.apply( this, arguments );
+    } else if (typeof method === 'object' || !method) {
+      return methods.init.apply(this, arguments);
     } else {
       $.error('Method ' + method + ' does not exist on jQuery.sticky');
     }
@@ -276,12 +316,13 @@
   $.fn.unstick = function(method) {
     if (methods[method]) {
       return methods[method].apply(this, slice.call(arguments, 1));
-    } else if (typeof method === 'object' || !method ) {
-      return methods.unstick.apply( this, arguments );
+    } else if (typeof method === 'object' || !method) {
+      return methods.unstick.apply(this, arguments);
     } else {
       $.error('Method ' + method + ' does not exist on jQuery.sticky');
     }
   };
+
   $(function() {
     setTimeout(scroller, 0);
   });


### PR DESCRIPTION
The plugin is currently attaching one single scroll listener to the window

In some HTML layouts there are only specific elements that are scrollable and in those cases `$(window).on('scroll', handler)` has no effect, the `handler` is never called.

This PR will allow a dev to define which element to attach the scroll listener to :

```
$(element).sticky({
  ....
  ...
  scroller: document.getElementById('my-scroller')
});
```

If no `scroller` is defined then `window` will be used instead.