### PR TITLE
Made sticky wrapper Id unique on page

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -158,7 +158,8 @@
           var stickyElement = $(this);
 
           var stickyId = stickyElement.attr('id');
-          var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName;
+          var wrapperIdSuffix = stickyId ? stickyId : new Date().valueOf();
+          var wrapperId = defaults.wrapperClassName + '-' + wrapperIdSuffix;
           var wrapper = $('<div></div>')
             .attr('id', wrapperId)
             .addClass(o.wrapperClassName);


### PR DESCRIPTION
There is closed [an issue](https://github.com/garand/sticky/issues/21) related to bad ID of sticky wrapper element: `id="undefined-sticky-wrapper"`


Current [line](https://github.com/garand/sticky/blob/master/jquery.sticky.js#L161) from master branch defines wrapper ID:
```
var wrapperId = stickyId ? stickyId + '-' + defaults.wrapperClassName : defaults.wrapperClassName;
```

It means if your sticky element has `id="dummy"`, wrapper will have `id="dummy-sticky-wrapper"`.
If your sticky element does not have an ID - wrapper will have `id="undefined-sticky-wrapper"`.

There is a problem when we have a few sticky elements on page without id (sidebar and header etc.)
it's not good to have two wrappers with that same id "undefined-sticky-wrapper"

How about to change this line with:
```
var wrapperIdSuffix = stickyId ? stickyId : new Date().valueOf();
var wrapperId = defaults.wrapperClassName + '-' + wrapperIdSuffix;
```

In this case wrapper id with will be more readable and it will be always unique on page (because timestamp is unique).



